### PR TITLE
Add color previews for colors written with commas

### DIFF
--- a/src/lib/colorUtils/index.ts
+++ b/src/lib/colorUtils/index.ts
@@ -2,7 +2,7 @@ import vscode from 'vscode';
 import tinycolor from 'tinycolor2';
 
 export function hslToRgb(colorStr: string): vscode.Color | undefined {
-  const hsl = colorStr.split(" ").map(it => it.trim());
+  const hsl = colorStr.replace(/,/g, "").split(" ").map(it => it.trim());
   const hslLen = hsl.length;
   if ((hslLen !== 3) && (hslLen !== 4)) {
     return undefined;

--- a/src/listener/utils/index.ts
+++ b/src/listener/utils/index.ts
@@ -34,7 +34,7 @@ export function createColorDecorator(preview: Preview, language: string): vscode
   const value = preview.variable.value;
 
   // distinguish between hex and hsl using percentage sign
-  const valueSplit = value.split(" ");
+  const valueSplit = value.replace(/,/g, "").split(" ");
   if (valueSplit.length >= 3) {
     const [h, s, l] = valueSplit;
     const isValidHsl = s.endsWith("%") && l.endsWith("%");


### PR DESCRIPTION
Colors can be defined using commas, e.g.: 
`--background: 111, 50%, 15%, 0.45;`
These changes allow parsing of such colors as well